### PR TITLE
Add Version header for proper package.el compatibility

### DIFF
--- a/smartscan.el
+++ b/smartscan.el
@@ -4,6 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey@masteringemacs.org>
 ;; Keywords: extensions
+;; Version: DEV
 
 ;;; Contributions
 ;; Thanks to Ryan Mulligan and Thomas Wallrafen


### PR DESCRIPTION
With this fix, the file can be installed using package.el, e.g. from the convenient packages automatically built by
[MELPA](http://melpa.milkbox.net). The fix is according to the [GNU Emacs Manual](http://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html).
