### PR TITLE
only consider `-` part of word in lisp

### DIFF
--- a/smartscan.el
+++ b/smartscan.el
@@ -101,7 +101,11 @@ either `smartscan-symbol-go-forward' or `smartscan-symbol-go-backward'")
      ;; parameter with `thing-at-point' will treat underscore as a word
      ;; separator.
      (modify-syntax-entry ?_ "w")
-     (modify-syntax-entry ?- "w")
+     (when (or (derived-mode-p 'emacs-lisp-mode)
+               (derived-mode-p 'lisp-mode)
+               (derived-mode-p 'scheme-mode)
+               (derived-mode-p 'clojure-mode))
+       (modify-syntax-entry ?- "w"))
      ,body))
 
 (defun smartscan-symbol-goto (name direction)


### PR DESCRIPTION
Before, smartscan would consider `-` like any other letter.
This meant if you had code like:

    foo->next = NULL;
    free(foo);

and you try to use smartscan on `foo->next`, you'll get

    Forward scan for symbol "foo-"

...failing to reach the second instance of `foo`. This meant smartscan
would sometimes not give the right result in C and C++ code, which was a
real pain.

This commit fixes that problem by only including `-` in the syntax table
if the major mode is a lisp-like language.