### PR TITLE
derive temp syntax table from current table

### DIFF
--- a/smartscan.el
+++ b/smartscan.el
@@ -99,7 +99,7 @@ either `smartscan-symbol-go-forward' or `smartscan-symbol-go-backward'")
 (defmacro smartscan-with-symbol (body)
   "Macro that initialises the syntax table"
   (declare (indent defun))
-  `(with-syntax-table (make-syntax-table)
+  `(with-syntax-table (make-syntax-table (syntax-table))
      (if smartscan-use-extended-syntax
          (modify-syntax-entry ?. "w"))
      ;; we need this outside the if-statement as using the word


### PR DESCRIPTION
`make-syntax-table` copies `standard-syntax-table` by default, but it seems better to use the current syntax table.

I'm not entirely sure if this is the correct thing to do, but it works better in `python-mode` (the built in one), and doesn't break other modes I've tried (`elisp-mode`, `sh-mode`, `c-mode`).