### PR TITLE
Do not message the user on movement

### DIFF
--- a/smartscan.el
+++ b/smartscan.el
@@ -127,9 +127,6 @@ is valid."
     (setq smartscan-last-symbol-name name)
     (push-mark))
   (setq smartscan-symbol-old-pt (point))
-  (message (format "%s scan for symbol \"%s\""
-                   (capitalize (symbol-name direction))
-                   smartscan-last-symbol-name))
   (smartscan-with-symbol
     (unless (catch 'done
               (while (funcall (cond


### PR DESCRIPTION
As you wrote in your excellent [blog post on eldoc](https://www.masteringemacs.org/article/seamlessly-merge-multiple-documentation-sources-eldoc), space in the echo area is a precious resource. Therefore, I think movement commands should not spam it with messages when they are doing exactly what they should. It also falls in line with the unix rule of silence that programs should not say anything when everything went as it should.