### PR TITLE
Normalize development version marker

### DIFF
--- a/smartscan.el
+++ b/smartscan.el
@@ -5,7 +5,7 @@
 ;; Author: Mickey Petersen <mickey@masteringemacs.org>
 ;; Maintainer: Mickey Petersen <mickey@masteringemacs.org>
 ;; Keywords: extensions
-;; Version: 0.0.0-git
+;; Version: 1.0.0-git
 
 ;;; Contributions
 ;; Thanks to Ryan Mulligan, Thomas Wallrafen, Brian Malehorn and Steve


### PR DESCRIPTION
## Summary
- normalize `smartscan.el` to the `1.0.0-git` development marker

## Validation
- native Emacs 30.2 package metadata parsing
- byte-compile and load smoke test
- `git diff --check`